### PR TITLE
fix: `align-attributes` rule for keys w/o values

### DIFF
--- a/lib/rules/align-attributes.js
+++ b/lib/rules/align-attributes.js
@@ -28,6 +28,7 @@ module.exports = {
     let metadata = [];
     let start = {};
     let end = {};
+
     for (const comment of comments.filter(
       (comment) => comment.type === 'Line'
     )) {
@@ -35,17 +36,27 @@ module.exports = {
         continue;
       }
 
+      const commentValue = comment.value.trim();
+
       // istanbul ignore else
-      if (inMetadata && comment.value.trim() === '==/UserScript==') {
+      if (inMetadata && commentValue === '==/UserScript==') {
         end = comment.loc.end;
         done = true;
-      } else if (!inMetadata && comment.value.trim() === '==UserScript==') {
+      } else if (!inMetadata && commentValue === '==UserScript==') {
         start = comment.loc.start;
         inMetadata = true;
-      } else if (inMetadata && comment.value.trim().startsWith('@')) {
+      } else if (inMetadata && commentValue.startsWith('@')) {
+        // Get space string between key and value
+        const [, spaceString] = /^\S*(\s*)/.exec(commentValue.slice(1));
+
+        // Keys w/o value must not be validated
+        if (spaceString.length === 0) {
+          continue;
+        }
+
         metadata.push({
-          key: comment.value.trim().slice(1).split(/\s/)[0],
-          space: /^\S*(\s+)/.exec(comment.value.trim().slice(1))[1].length,
+          key: commentValue.slice(1).split(/\s/)[0],
+          space: spaceString.length,
           line: comment.loc.start.line,
           comment
         });
@@ -61,14 +72,15 @@ module.exports = {
     }
 
     const totalSpacing =
-      Math.max(...metadata.map((metadatapoint) => metadatapoint.key.length)) +
-      spacing;
+      Math.max(...metadata.map(({ key }) => key.length)) + spacing;
+
+    const hasSpaceLessThenSpacing =
+      metadata.map(({ space }) => space).sort()[0] < spacing;
 
     if (
-      metadata.map((metadatapoint) => metadatapoint.space).sort()[0] <
-        spacing ||
+      hasSpaceLessThenSpacing ||
       metadata
-        .map((metadatapoint) => metadatapoint.key.length + metadatapoint.space)
+        .map(({ key, space }) => key.length + space)
         .some((val) => val !== totalSpacing)
     ) {
       context.report({

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1,5 +1,6 @@
 const requireindex = require('requireindex');
 const fs = require('fs');
+const path = require('path');
 
 require('should');
 
@@ -14,4 +15,6 @@ describe('config', () => {
   });
 });
 
-module.exports = requireindex(__dirname.replace(/\/tests(\/lib)$/, '$1/rules'));
+module.exports = requireindex(
+  __dirname.replace(/[/\\]tests([/\\]lib)$/, `$1${path.sep}rules`)
+);

--- a/tests/lib/rules/align-attributes.js
+++ b/tests/lib/rules/align-attributes.js
@@ -11,6 +11,7 @@ ruleTester.run('align-attributes', rule, {
     // ==/UserScript==`,
     `// ==UserScript==
     // @name         hello
+    // @noframes
     // @description  hello also
     // ==/UserScript==`,
     {
@@ -41,10 +42,12 @@ ruleTester.run('align-attributes', rule, {
       code: `// ==UserScript==
       // @name                  some name
       // @description hey there
+      // @nowrap
       `,
       output: `// ==UserScript==
       // @name            some name
       // @description     hey there
+      // @nowrap
       `,
       options: [5],
       errors: [


### PR DESCRIPTION
- Handle case when key does not have value (e.g. `@noframes`, `@nowrap`) - Ignore such comments
- Add some comments and variables to improve readability
- Update tests to cover the fixed case
- Fix running tests on Windows

Fixes #39