### PR TITLE
add support for adguard as a userscript manager

### DIFF
--- a/lib/data/compat-grant.ts
+++ b/lib/data/compat-grant.ts
@@ -6,10 +6,12 @@ import type { CompatMap, VersionAssertion } from './version-assertion';
 // - Greasemonkey: https://wiki.greasespot.net/Greasemonkey_Manual:API
 export const compatMap: CompatMap = {
   'GM.addElement': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.11.6113' },
     { type: 'violentmonkey', versionConstraint: '>=2.13.0-beta.3' }
   ],
   GM_addElement: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.11.6113' },
     { type: 'violentmonkey', versionConstraint: '>=2.13.0-beta.3' }
   ],
@@ -18,6 +20,7 @@ export const compatMap: CompatMap = {
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' }
   ],
   GM_addStyle: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.6.1.4 <4' }
@@ -32,11 +35,13 @@ export const compatMap: CompatMap = {
   'GM.cookie': [{ type: 'tampermonkey', versionConstraint: '>=4.8' }],
   GM_cookie: [{ type: 'tampermonkey', versionConstraint: '>=4.8' }],
   'GM.deleteValue': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4.0' }
   ],
   GM_deleteValue: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.8.20090123.1 <4' }
@@ -50,6 +55,7 @@ export const compatMap: CompatMap = {
   ],
   'GM.getResourceText': [{ type: 'tampermonkey', versionConstraint: '>=4.5' }],
   GM_getResourceText: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.8.20080609.0 <4' }
@@ -58,11 +64,13 @@ export const compatMap: CompatMap = {
     { type: 'violentmonkey', versionConstraint: '>=2.12.0 <2.13.0.10' }
   ],
   GM_getResourceURL: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.8.20080609.0 <4' }
   ],
   'GM.getResourceUrl': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.13.0.10' },
     { type: 'greasemonkey', versionConstraint: '>=4.0' }
@@ -72,11 +80,13 @@ export const compatMap: CompatMap = {
   'GM.getTabs': [{ type: 'tampermonkey', versionConstraint: '>=4.5' }],
   GM_getTabs: [{ type: 'tampermonkey', versionConstraint: '>=4.0.10' }],
   'GM.getValue': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4.0' }
   ],
   GM_getValue: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.3-beta <4' }
@@ -84,21 +94,25 @@ export const compatMap: CompatMap = {
   'GM.getValues': [{ type: 'tampermonkey', versionConstraint: '>=5.3' }],
   GM_getValues: [{ type: 'tampermonkey', versionConstraint: '>=5.3' }],
   'GM.info': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4' }
   ],
   GM_info: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=2.4.2718' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.9.16 <4' }
   ],
   'GM.listValues': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4' }
   ],
   GM_listValues: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.8.20090123.1 <4' }
@@ -108,11 +122,13 @@ export const compatMap: CompatMap = {
     { type: 'greasemonkey', versionConstraint: '>=4' }
   ],
   GM_log: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.3-beta <4' }
   ],
   'GM.notification': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4' }
@@ -122,11 +138,13 @@ export const compatMap: CompatMap = {
     { type: 'violentmonkey', versionConstraint: '>=2.5.0' }
   ],
   'GM.openInTab': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4' }
   ],
   GM_openInTab: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.5-beta <4' }
@@ -151,21 +169,25 @@ export const compatMap: CompatMap = {
   'GM.saveTab': [{ type: 'tampermonkey', versionConstraint: '>=4.5' }],
   GM_saveTab: [{ type: 'tampermonkey', versionConstraint: '>=4.0.10' }],
   'GM.setClipboard': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4' }
   ],
   GM_setClipboard: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=2.6.2767' },
     { type: 'violentmonkey', versionConstraint: '>=2.5.0' },
     { type: 'greasemonkey', versionConstraint: '>=1.10 <4' }
   ],
   'GM.setValue': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4' }
   ],
   GM_setValue: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.3-beta <4' }
@@ -182,21 +204,25 @@ export const compatMap: CompatMap = {
   'GM.webRequest': [{ type: 'tampermonkey', versionConstraint: '>=4.5 <=5.2' }],
   GM_webRequest: [{ type: 'tampermonkey', versionConstraint: '>=4.4 <=5.2' }],
   GM_xmlhttpRequest: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.2.5 <4' }
   ],
   'GM.xmlHttpRequest': [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '>=4.5' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.0' },
     { type: 'greasemonkey', versionConstraint: '>=4.0' }
   ],
   none: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '*' }
   ],
   unsafeWindow: [
+    { type: 'adguard', versionConstraint: '*' },
     { type: 'tampermonkey', versionConstraint: '*' },
     { type: 'violentmonkey', versionConstraint: '*' },
     { type: 'greasemonkey', versionConstraint: '>=0.5-beta' }
@@ -209,7 +235,10 @@ export const compatMap: CompatMap = {
     { type: 'tampermonkey', versionConstraint: '>=3.12.58' },
     { type: 'violentmonkey', versionConstraint: '>=2.12.10' }
   ],
-  'window.onurlchange': [{ type: 'tampermonkey', versionConstraint: '>=4.11' }]
+  'window.onurlchange': [{ type: 'tampermonkey', versionConstraint: '>=4.11' }],
+  'property:settings': [
+    { type: 'adguard', versionConstraint: '*' },
+  ]
 };
 
 export const gmPolyfillOverride: {

--- a/lib/data/compat-headers.ts
+++ b/lib/data/compat-headers.ts
@@ -1,6 +1,7 @@
 import { CompatMap } from './version-assertion';
 
 // Documentation:
+// - Adguard: https://adguard.com/kb/general/extensions/#development
 // - Tampermonkey: https://www.tampermonkey.net/documentation.php
 // - Violentmonkey: https://violentmonkey.github.io/api/metadata-block/
 // - Greasemonkey: https://wiki.greasespot.net/Metadata_Block
@@ -11,11 +12,13 @@ export const compatMap: {
 } = {
   localized: {
     name: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '>=3.9' },
       { type: 'violentmonkey', versionConstraint: '>=2.1.6.8' },
       { type: 'greasemonkey', versionConstraint: '>=2.2 <4 || >=4.11' }
     ],
     description: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '>=3.9' },
       { type: 'violentmonkey', versionConstraint: '>=2.1.6.8' },
       { type: 'greasemonkey', versionConstraint: '>=2.2 <4 || >=4.11' }
@@ -27,22 +30,26 @@ export const compatMap: {
   },
   unlocalized: {
     include: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '*' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '*' }
     ],
     exclude: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '*' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '*' }
     ],
     'exclude-match': [{ type: 'violentmonkey', versionConstraint: '>=2.6.2' }],
     version: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '*' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.9.0' }
     ],
     'run-at': [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '>=1.1.2190' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.9.8' }
@@ -52,16 +59,19 @@ export const compatMap: {
       { type: 'tampermonkey', versionConstraint: '>=5.3' }
     ],
     resource: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '*' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.8.20080609.0' }
     ],
     require: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '*' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.8.20080609.0' }
     ],
     match: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '>=1.1.2190' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.9.8' }
@@ -73,16 +83,19 @@ export const compatMap: {
       { type: 'violentmonkey', versionConstraint: '>=2.13.0.16' }
     ],
     grant: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '>=3.0.3389' },
       { type: 'violentmonkey', versionConstraint: '>=2.1.6.1' },
       { type: 'greasemonkey', versionConstraint: '>=1' }
     ],
     noframes: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'violentmonkey', versionConstraint: '>=2.8.17' },
       { type: 'greasemonkey', versionConstraint: '>=2.3' },
       { type: 'tampermonkey', versionConstraint: '>=2.0.2355' }
     ],
     connect: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '>=4.0' },
       { type: 'violentmonkey', versionConstraint: '>=2.12.10' }
     ],
@@ -102,11 +115,13 @@ export const compatMap: {
   },
   nonFunctional: {
     name: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '*' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '*' }
     ],
     description: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '*' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '*' }
@@ -125,36 +140,55 @@ export const compatMap: {
     ],
     license: [{ type: 'tampermonkey', versionConstraint: '*' }],
     icon: [
+      { type: 'adguard', versionConstraint: '*'},
       { type: 'tampermonkey', versionConstraint: '>=2.0.2359' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.9.0' }
     ],
-    defaulticon: [{ type: 'tampermonkey', versionConstraint: '>=2.0.2359' }],
-    icon64: [{ type: 'tampermonkey', versionConstraint: '>=2.0.2359' }],
-    iconURL: [{ type: 'tampermonkey', versionConstraint: '>=2.0.2359' }],
-    icon64URL: [{ type: 'tampermonkey', versionConstraint: '>=2.0.2359' }],
+    defaulticon: [
+      { type: 'adguard', versionConstraint: '*' },
+      { type: 'tampermonkey', versionConstraint: '>=2.0.2359' }
+    ],
+    icon64: [
+      { type: 'adguard', versionConstraint: '*' },
+      { type: 'tampermonkey', versionConstraint: '>=2.0.2359' }
+    ],
+    iconURL: [
+      { type: 'adguard', versionConstraint: '*' },
+      { type: 'tampermonkey', versionConstraint: '>=2.0.2359' }
+    ],
+    icon64URL: [
+      { type: 'adguard', versionConstraint: '*' },
+      { type: 'tampermonkey', versionConstraint: '>=2.0.2359' }
+    ],
     homepage: [
+      { type: 'adguard', versionConstraint: '*' },
       { type: 'tampermonkey', versionConstraint: '>=2.0.2395' },
       { type: 'violentmonkey', versionConstraint: '*' }
     ],
     homepageURL: [
+      { type: 'adguard', versionConstraint: '*' },
       { type: 'tampermonkey', versionConstraint: '>=2.0.2395' },
       { type: 'violentmonkey', versionConstraint: '>=2.1.5' }
     ],
     website: [
+      { type: 'adguard', versionConstraint: '*' },
       { type: 'tampermonkey', versionConstraint: '>=2.0.2395' },
       { type: 'violentmonkey', versionConstraint: '>=2.13.1.2' }
     ],
     source: [
+      { type: 'adguard', versionConstraint: '*' },
       { type: 'tampermonkey', versionConstraint: '>=2.0.2395' },
       { type: 'violentmonkey', versionConstraint: '>=2.13.1.2' }
     ],
     downloadURL: [
+      { type: 'adguard', versionConstraint: '*' },
       { type: 'tampermonkey', versionConstraint: '>=2.5.64' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.9.14' }
     ],
     updateURL: [
+      { type: 'adguard', versionConstraint: '*' },
       { type: 'tampermonkey', versionConstraint: '>=2.5.64' },
       { type: 'violentmonkey', versionConstraint: '*' },
       { type: 'greasemonkey', versionConstraint: '>=0.9.12' }

--- a/lib/data/version-assertion.ts
+++ b/lib/data/version-assertion.ts
@@ -1,5 +1,5 @@
 export type VersionAssertion = {
-  type: 'tampermonkey' | 'violentmonkey' | 'greasemonkey';
+  type: 'adguard' | 'tampermonkey' | 'violentmonkey' | 'greasemonkey';
   versionConstraint: string;
 };
 

--- a/tests/lib/data/compat-grant.ts
+++ b/tests/lib/data/compat-grant.ts
@@ -10,7 +10,7 @@ function validateCompatibilityData(compatabilityData: VersionAssertion[]) {
       compatabilityAssertion.should.have
         .property('type')
         .a.String()
-        .equalOneOf(['tampermonkey', 'greasemonkey', 'violentmonkey']);
+        .equalOneOf(['adguard', 'tampermonkey', 'greasemonkey', 'violentmonkey']);
       compatabilityAssertion.should.have.property('versionConstraint').a.String;
     }
   );

--- a/tests/lib/data/compat-headers.ts
+++ b/tests/lib/data/compat-headers.ts
@@ -24,6 +24,7 @@ describe('headers data', () => {
                   .property('type')
                   .a.String()
                   .equalOneOf([
+                    'adguard',
                     'tampermonkey',
                     'greasemonkey',
                     'violentmonkey'

--- a/tests/lib/rules/compat-grant.ts
+++ b/tests/lib/rules/compat-grant.ts
@@ -45,6 +45,7 @@ ruleTester.run('compat-grant', compatGrant, {
       options: [{ requireAllCompatible: true }],
       settings: {
         userscriptVersions: {
+          adguard: '*',
           tampermonkey: '*',
           greasemonkey: '*'
         }
@@ -69,6 +70,7 @@ ruleTester.run('compat-grant', compatGrant, {
       options: [{ requireAllCompatible: true, gmPolyfill: true }],
       settings: {
         userscriptVersions: {
+          adguard: '*',
           violentmonkey: '*',
           tampermonkey: '*',
           greasemonkey: '*'
@@ -82,6 +84,7 @@ ruleTester.run('compat-grant', compatGrant, {
       options: [{ requireAllCompatible: true, gmPolyfill: false }],
       settings: {
         userscriptVersions: {
+          adguard: '*',
           violentmonkey: '*',
           tampermonkey: '*',
           greasemonkey: '*'
@@ -98,6 +101,7 @@ ruleTester.run('compat-grant', compatGrant, {
       options: [{ requireAllCompatible: true, gmPolyfill: false }],
       settings: {
         userscriptVersions: {
+          adguard: '*',
           violentmonkey: '*',
           tampermonkey: '*',
           greasemonkey: '*'


### PR DESCRIPTION
Adguard, a piece of cross-platform adblocking software, functions as a cross-browser userscript manager on the platforms where it's available, so I added support for it in this plugin.

Relevant information about userscript headers and @grants that Adguard recognizes: https://adguard.com/kb/general/extensions/#development